### PR TITLE
Adiciona limpeza dos sinais de pontuação nos números

### DIFF
--- a/pycpfcnpj/cpfcnpj.py
+++ b/pycpfcnpj/cpfcnpj.py
@@ -1,3 +1,6 @@
+import string
+
+
 from . import cpf
 from . import cnpj
 
@@ -7,15 +10,17 @@ def validate(number):
        and validates either CPF and CNPJ numbers.
        Feel free to use this or the other modules directly.
 
-       :param number: a CPF or CNPJ number. Only numbers.
+       :param number: a CPF or CNPJ number. Clear number to have only numbers.
        :type number: string
        :return: Bool -- True if number is a valid CPF or CNPJ number.
                 False if it is not or do not complain
                 with the right size of these numbers.
 
     """
-    if len(number) == 11:
-        return cpf.validate(number)
-    elif len(number) == 14:
-        return cnpj.validate(number)
+    clean_number = number.translate(str.maketrans("", "", string.punctuation))
+
+    if len(clean_number) == 11:
+        return cpf.validate(clean_number)
+    elif len(clean_number) == 14:
+        return cnpj.validate(clean_number)
     return False

--- a/tests/cpfcnpj_tests.py
+++ b/tests/cpfcnpj_tests.py
@@ -12,6 +12,13 @@ class CPFCNPJTests(unittest.TestCase):
         self.invalid_cnpj = '11444777000162'
         self.invalid_cnpj_size = '114447770001'
 
+        self.mascared_valid_cpf = '111.444.777-35'
+        self.mascared_invalid_cpf = '111.444.777-36'
+        self.mascared_invalid_cpf_size = '111.444.777'
+        self.mascared_valid_cnpj = '11.444.777/0001-61'
+        self.mascared_invalid_cnpj = '11.444.777/0001-62'
+        self.mascared_invalid_cnpj_size = '114.447/7700-01'
+
     def test_validate_cpf_true(self):
         self.assertTrue(cpfcnpj.validate(self.valid_cpf))
 
@@ -29,6 +36,25 @@ class CPFCNPJTests(unittest.TestCase):
 
     def test_wrong_cnpj_size(self):
         self.assertFalse(cpfcnpj.validate(self.invalid_cnpj_size))
+
+    def mascared_test_validate_cpf_true(self):
+        self.assertTrue(cpfcnpj.validate(self.mascared_valid_cpf))
+
+    def mascared_test_validate_cpf_false(self):
+        self.assertFalse(cpfcnpj.validate(self.mascared_invalid_cpf))
+
+    def mascared_test_validate_cnpj_true(self):
+        self.assertTrue(cpfcnpj.validate(self.mascared_valid_cnpj))
+
+    def mascared_test_validate_cnpj_false(self):
+        self.assertFalse(cpfcnpj.validate(self.mascared_invalid_cnpj))
+
+    def mascared_test_wrong_cpf_size(self):
+        self.assertFalse(cpfcnpj.validate(self.mascared_invalid_cpf_size))
+
+    def mascared_test_wrong_cnpj_size(self):
+        self.assertFalse(cpfcnpj.validate(self.mascared_invalid_cnpj_size))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Esse PR permite à biblioteca analisar números de documentos que contenham sinais de pontuação como `.`, '-', ou '/'.