### PR TITLE
Add random cpf/cnpj generation with formated output

### DIFF
--- a/pycpfcnpj/gen.py
+++ b/pycpfcnpj/gen.py
@@ -4,15 +4,34 @@ from . import cpf as cpf_module
 from . import cnpj as cnpj_module
 
 
-def cpf():
+def put_mask(number, mask):
+    new_number = ''
+
+    first = 0
+    for last, signal in mask:
+        new_number += number[first:last] + signal
+        first = last
+
+    return new_number + number[last:]
+
+
+def cpf(mask=False):
     cpf_ramdom = ''.join(random.choice(string.digits) for i in range(11))
     while not cpf_module.validate(cpf_ramdom):
         cpf_ramdom = ''.join(random.choice(string.digits) for i in range(11))
+
+    if mask:
+        return put_mask(cpf_ramdom, ((3, '.'), (6, '.'), (9, '-')))
+
     return cpf_ramdom
 
 
-def cnpj():
+def cnpj(mask=False):
     cnpj_ramdom = ''.join(random.choice(string.digits) for i in range(14))
     while not cnpj_module.validate(cnpj_ramdom):
         cnpj_ramdom = ''.join(random.choice(string.digits) for i in range(14))
+
+    if mask:
+        return put_mask(cnpj_ramdom, ((2, '.'), (5, '.'), (8,'/'), (12, '-')))
+
     return cnpj_ramdom

--- a/tests/cnpj_tests.py
+++ b/tests/cnpj_tests.py
@@ -1,5 +1,8 @@
 import unittest
+
 from pycpfcnpj import cnpj
+from pycpfcnpj.gen import cnpj as gen_cnpj
+from pycpfcnpj.gen import put_mask
 
 
 class CNPJTests(unittest.TestCase):
@@ -12,21 +15,39 @@ class CNPJTests(unittest.TestCase):
 
     def test_validate_cnpj_true(self):
         self.assertTrue(cnpj.validate(self.valid_cnpj))
-    
+
     def test_validate_masked_cnpj_true(self):
         self.assertTrue(cnpj.validate(self.masked_valid_cnpj))
 
     def test_validate_cnpj_false(self):
         self.assertFalse(cnpj.validate(self.invalid_cnpj))
-    
+
     def test_validate_masked_cnpj_false(self):
         self.assertFalse(cnpj.validate(self.invalid_cnpj))
-        
+
     def test_validate_cnpj_with_same_numbers(self):
         for i in range(10):
             self.assertFalse(cnpj.validate(
                 '{0}'.format(i) * 14
             ))
+
+    def test_put_mask_cnpj(self):
+        with_mask = put_mask(
+            self.valid_cnpj,
+            ((2, '.'), (5, '.'), (8,'/'), (12, '-'))
+        )
+        self.assertEqual(with_mask, self.masked_valid_cnpj)
+
+    def test_gen_cnpf_with_default_mask_tag(self):
+        cnpj = gen_cnpj()
+        self.assertEqual(len(cnpj), 14)
+        self.assertTrue(cnpj.isdigit())
+
+    def test_gen_cnpj_with_mask(self):
+        cnpj = gen_cnpj(mask=True)
+        self.assertEqual(len(cnpj), 18)
+        self.assertFalse(cnpj.isdigit())
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/cpf_tests.py
+++ b/tests/cpf_tests.py
@@ -1,5 +1,8 @@
 import unittest
+
 from pycpfcnpj import cpf
+from pycpfcnpj.gen import cpf as gen_cpf
+from pycpfcnpj.gen import put_mask
 
 
 class CPFTests(unittest.TestCase):
@@ -13,21 +16,36 @@ class CPFTests(unittest.TestCase):
 
     def test_validate_cpf_true(self):
         self.assertTrue(cpf.validate(self.valid_cpf))
-    
+
     def test_validate_masked_cpf_true(self):
         self.assertTrue(cpf.validate(self.masked_valid_cpf))
 
     def test_validate_cpf_false(self):
         self.assertFalse(cpf.validate(self.invalid_cpf))
-    
+
     def test_validate_masked_cpf_false(self):
         self.assertFalse(cpf.validate(self.masked_invalid_cpf))
-    
+
     def test_validate_cpf_with_same_numbers(self):
         for i in range(10):
             self.assertFalse(cpf.validate(
                 '{0}'.format(i) * 11
             ))
+
+    def test_put_mask_cpf(self):
+        with_mask = put_mask(self.valid_cpf, ((3, '.'), (6, '.'), (9, '-')))
+        self.assertEqual(with_mask, self.masked_valid_cpf)
+
+    def test_gen_cpf_with_default_mask_tag(self):
+        cpf = gen_cpf()
+        self.assertEqual(len(cpf), 11)
+        self.assertTrue(cpf.isdigit())
+
+    def test_gen_cpf_with_mask(self):
+        cpf = gen_cpf(mask=True)
+        self.assertEqual(len(cpf), 14)
+        self.assertFalse(cpf.isdigit())
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR add option to generate random cpf/cnpj with punctuation marks, conform #11.