### PR TITLE
Removed unnecessary loops to create a random CPF and CNPJ

### DIFF
--- a/pycpfcnpj/calculation.py
+++ b/pycpfcnpj/calculation.py
@@ -1,47 +1,62 @@
 DIVISOR = 11
 
+CPF_WEIGHTS = ((10, 9, 8, 7, 6, 5, 4, 3, 2),
+              (11, 10, 9, 8, 7, 6, 5, 4, 3, 2))
+CNPJ_WEIGHTS = ((5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2),
+               (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2))
 
-def first_check_digit(number, weighs):
-    """ This function calculates the first check digit to
-        verify a cpf or cnpj vality.
 
-        :param number: cpf or cnpj number to check the first
-                       digit.  Only numbers.
+
+def calculate_first_digit(number):
+    """ This function calculates the first check digit of a
+        cpf or cnpj.
+
+        :param number: cpf (length 9) or cnpf (length 12) 
+            string to check the first digit. Only numbers.
         :type number: string
-        :param weighs: weighs related to first check digit
-                       calculation
-        :type weighs: list of integers
-        :returns: string -- the first digit
+        :returns: string -- the first digit, X if invalid size
 
     """
 
     sum = 0
-    for i in range(len(weighs)):
-        sum = sum + int(number[i]) * weighs[i]
+    if len(number) == 9:
+        weights = CPF_WEIGHTS[0]
+    elif len(number) == 12:
+        weights = CNPJ_WEIGHTS[0]
+    else:
+        return 'X'
+
+    for i in range(len(number)):
+        sum = sum + int(number[i]) * weights[i]
     rest_division = sum % DIVISOR
     if rest_division < 2:
         return '0'
     return str(11 - rest_division)
 
 
-def second_check_digit(updated_number, weighs):
-    """ This function calculates the second check digit to
-        verify a cpf or cnpj vality.
+def calculate_second_digit(number):
+    """ This function calculates the second check digit of
+        a cpf or cnpj.
 
         **This function must be called after the above.**
 
-        :param updated_number: cpf or cnpj number with the
-                               first digit.  Only numbers.
+        :param number: cpf (length 10) or cnpj 
+            (length 13) number with the first digit. Only numbers.
         :type number: string
-        :param weighs: weighs related to second check digit calculation
-        :type weighs: list of integers
-        :returns: string -- the second digit
+        :returns: string -- the second digit, X if invalid size
 
     """
 
     sum = 0
-    for i in range(len(weighs)):
-        sum = sum + int(updated_number[i]) * weighs[i]
+    if len(number) == 10:
+        weights = CPF_WEIGHTS[1]
+    elif len(number) == 13:
+        weights = CNPJ_WEIGHTS[1]
+    else:
+        return 'X'
+
+    for i in range(len(number)):
+        sum = sum + int(number[i]) * weights[i]
     rest_division = sum % DIVISOR
     if rest_division < 2:
         return '0'

--- a/pycpfcnpj/calculation.py
+++ b/pycpfcnpj/calculation.py
@@ -14,17 +14,15 @@ def calculate_first_digit(number):
         :param number: cpf (length 9) or cnpf (length 12) 
             string to check the first digit. Only numbers.
         :type number: string
-        :returns: string -- the first digit, X if invalid size
+        :returns: string -- the first digit
 
     """
 
     sum = 0
     if len(number) == 9:
         weights = CPF_WEIGHTS[0]
-    elif len(number) == 12:
-        weights = CNPJ_WEIGHTS[0]
     else:
-        return 'X'
+        weights = CNPJ_WEIGHTS[0]
 
     for i in range(len(number)):
         sum = sum + int(number[i]) * weights[i]
@@ -43,17 +41,15 @@ def calculate_second_digit(number):
         :param number: cpf (length 10) or cnpj 
             (length 13) number with the first digit. Only numbers.
         :type number: string
-        :returns: string -- the second digit, X if invalid size
+        :returns: string -- the second digit
 
     """
 
     sum = 0
     if len(number) == 10:
         weights = CPF_WEIGHTS[1]
-    elif len(number) == 13:
-        weights = CNPJ_WEIGHTS[1]
     else:
-        return 'X'
+        weights = CNPJ_WEIGHTS[1]
 
     for i in range(len(number)):
         sum = sum + int(number[i]) * weights[i]

--- a/pycpfcnpj/cnpj.py
+++ b/pycpfcnpj/cnpj.py
@@ -20,16 +20,13 @@ def validate(cnpj_number):
        len(set(_cnpj)) == 1):
         return False
 
-    first_cnpj_weighs = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
-    second_cnpj_weighs = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
     first_part = _cnpj[:12]
+    second_part = _cnpj[:13]
     first_digit = _cnpj[12]
     second_digit = _cnpj[13]
 
-    if (first_digit == calc.first_check_digit(first_part,
-                                              first_cnpj_weighs) and
-       second_digit == calc.second_check_digit(_cnpj[:13],
-                                               second_cnpj_weighs)):
+    if (first_digit == calc.calculate_first_digit(first_part) and
+       second_digit == calc.calculate_second_digit(second_part)):
         return True
 
     return False

--- a/pycpfcnpj/cpf.py
+++ b/pycpfcnpj/cpf.py
@@ -20,16 +20,13 @@ def validate(cpf_number):
        len(set(_cpf)) == 1):
         return False
 
-    first_cpf_weighs = [10, 9, 8, 7, 6, 5, 4, 3, 2]
-    second_cpf_weighs = [11, 10, 9, 8, 7, 6, 5, 4, 3, 2]
     first_part = _cpf[:9]
+    second_part = _cpf[:10]
     first_digit = _cpf[9]
     second_digit = _cpf[10]
 
-    if (first_digit == calc.first_check_digit(first_part,
-                                              first_cpf_weighs) and
-       second_digit == calc.second_check_digit(_cpf[:10],
-                                               second_cpf_weighs)):
+    if (first_digit == calc.calculate_first_digit(first_part) and
+       second_digit == calc.calculate_second_digit(second_part)):
         return True
 
     return False

--- a/pycpfcnpj/gen.py
+++ b/pycpfcnpj/gen.py
@@ -1,20 +1,21 @@
 import string
 import random
+from . import calculation as calc
 from . import cpf as cpf_module
 from . import cnpj as cnpj_module
 
 
 def cpf():
-    cpf_ramdom = ''.join(random.choice(string.digits) for i in range(11))
-    while not cpf_module.validate(cpf_ramdom):
-        cpf_ramdom = ''.join(random.choice(string.digits) for i in range(11))
+    cpf_ramdom = ''.join(random.choice(string.digits) for i in range(9))
+    cpf_ramdom += calc.calculate_first_digit(cpf_ramdom)
+    cpf_ramdom += calc.calculate_second_digit(cpf_ramdom)
     return cpf_ramdom
 
 
 def cnpj():
-    cnpj_ramdom = ''.join(random.choice(string.digits) for i in range(14))
-    while not cnpj_module.validate(cnpj_ramdom):
-        cnpj_ramdom = ''.join(random.choice(string.digits) for i in range(14))
+    cnpj_ramdom = ''.join(random.choice(string.digits) for i in range(12))
+    cnpj_ramdom += calc.calculate_first_digit(cnpj_ramdom)
+    cnpj_ramdom += calc.calculate_second_digit(cnpj_ramdom)
     return cnpj_ramdom
 
 

--- a/tests/calculation_tests.py
+++ b/tests/calculation_tests.py
@@ -19,64 +19,60 @@ class CalculationTests(unittest.TestCase):
     def setUp(self):
         self.first_part_cpf_number = '111444777'
         self.first_part_cnpj_number = '114447770001'
-        self.first_cpf_weighs = [10, 9, 8, 7, 6, 5, 4, 3, 2]
-        self.second_cpf_weighs = [11, 10, 9, 8, 7, 6, 5, 4, 3, 2]
-        self.first_cnpj_weighs = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
-        self.second_cnpj_weighs = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
 
     # TESTS FOR CPF DIGITS
-    def test_cpf_first_check_digit_true(self):
+    def test_cpf_calculate_first_digit_true(self):
         correct_first_digit = '3'
         self.assertEqual(correct_first_digit,
-                         calc.first_check_digit(self.first_part_cpf_number, self.first_cpf_weighs))
+                         calc.calculate_first_digit(self.first_part_cpf_number))
 
-    def test_cpf_first_check_digit_false(self):
+    def test_cpf_calculate_first_digit_false(self):
         incorrect_first_digit = '6'
         self.assertNotEqual(incorrect_first_digit,
-                            calc.first_check_digit(self.first_part_cpf_number, self.first_cpf_weighs))
+                            calc.calculate_first_digit(self.first_part_cpf_number))
 
-    def test_cpf_second_check_digit_true(self):
+    def test_cpf_calculate_second_digit_true(self):
         updated_cpf_number = self.first_part_cpf_number + \
-            calc.first_check_digit(
-                self.first_part_cpf_number, self.first_cpf_weighs)
+            calc.calculate_first_digit(
+                self.first_part_cpf_number)
         correct_second_digit = '5'
         self.assertEqual(correct_second_digit,
-                         calc.second_check_digit(updated_cpf_number, self.second_cpf_weighs))
+                         calc.calculate_second_digit(updated_cpf_number))
 
-    def test_cpf_second_check_digit_false(self):
+    def test_cpf_calculate_second_digit_false(self):
         updated_cpf_number = self.first_part_cpf_number + \
-            calc.first_check_digit(
-                self.first_part_cpf_number, self.first_cpf_weighs)
+            calc.calculate_first_digit(
+                self.first_part_cpf_number)
         incorrect_second_digit = '7'
         self.assertNotEqual(incorrect_second_digit,
-                            calc.second_check_digit(updated_cpf_number, self.second_cpf_weighs))
+                            calc.calculate_second_digit(updated_cpf_number))
 
     # TESTS FOR CNPJ DIGITS
-    def test_cnpj_first_check_digit_true(self):
+    def test_cnpj_calculate_first_digit_true(self):
         correct_first_digit = '6'
         self.assertEqual(correct_first_digit,
-                         calc.first_check_digit(self.first_part_cnpj_number, self.first_cnpj_weighs))
+                         calc.calculate_first_digit(self.first_part_cnpj_number))
 
-    def test_cnpj_first_check_digit_false(self):
+    def test_cnpj_calculate_first_digit_false(self):
         correct_first_digit = '7'
         self.assertNotEqual(correct_first_digit,
-                            calc.first_check_digit(self.first_part_cnpj_number, self.first_cnpj_weighs))
+                            calc.calculate_first_digit(self.first_part_cnpj_number))
 
-    def test_cnpj_second_check_digit_true(self):
+    def test_cnpj_calculate_second_digit_true(self):
         correct_second_digit = '1'
         updated_cnpj_number = self.first_part_cnpj_number + \
-            calc.first_check_digit(
-                self.first_part_cnpj_number, self.first_cnpj_weighs)
+            calc.calculate_first_digit(
+                self.first_part_cnpj_number)
         self.assertEqual(correct_second_digit,
-                         calc.second_check_digit(updated_cnpj_number, self.second_cnpj_weighs))
+                         calc.calculate_second_digit(updated_cnpj_number))
 
-    def test_cnpj_second_check_digit_false(self):
+    def test_cnpj_calculate_second_digit_false(self):
         correct_second_digit = '2'
         updated_cnpj_number = self.first_part_cnpj_number + \
-            calc.first_check_digit(
-                self.first_part_cnpj_number, self.first_cnpj_weighs)
+            calc.calculate_first_digit(
+                self.first_part_cnpj_number)
         self.assertNotEqual(correct_second_digit,
-                            calc.second_check_digit(updated_cnpj_number, self.second_cnpj_weighs))
+                            calc.calculate_second_digit(updated_cnpj_number))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This offers a significantly faster "gen" function for CPF and CNPJ:
Old:
```$ python -c 'import time;from pycpfcnpj import gen;start_time = time.time();gen.cpf();print("%s seconds" % (time.time() - start_time))'
0.00010704994201660156 seconds
``` 

New:
```
$ python -c 'import time;from pycpfcnpj import gen;start_time = time.time();gen.cpf();print("%s seconds" % (time.time() - start_time))'
2.6464462280273438e-05 seconds
```