### PR TITLE
Corrigir erros de digitação na documentação, sobre às variáves da tradução pt-BR

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ pip install pycpfcnpj
 ```python
 from pycpfcnpj import cpfcnpj
 cpf_number = '11144477735'
-masked_cpf_number = '111.444.777-35'
+cpf_number_mascara = '111.444.777-35'
 cnpj_number = '11444777000161'
-masked_cnpj_number = '11.444.777/0001-61'
+cnpj_number_mascara = '11.444.777/0001-61'
 
 print cpfcnpj.validate(cpf_number)
 print cpfcnpj.validate(cpf_number_mascara)


### PR DESCRIPTION
as variáveis que estão incorretas (vulgo ```cpf_number```, ```masked_cpf_number```, ```cnpj_number``` e ```masked_cnpj_number```), precisam ser consertadas, por que poderia, alguém seguir a documentação estritamente e acabar errando.