### PR TITLE
feat: add support for alphanumeric CNPJ (2026 spec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ cpf_number = '11144477735'
 masked_cpf_number = '111.444.777-35'
 cnpj_number = '11444777000161'
 masked_cnpj_number = '11.444.777/0001-61'
+alphanumeric_cnpj = '12ABC34501DE35'
 
 print(cpfcnpj.validate(cpf_number))
 print(cpfcnpj.validate(masked_cpf_number))
 print(cpfcnpj.validate(cnpj_number))
 print(cpfcnpj.validate(masked_cnpj_number))
+print(cpfcnpj.validate(alphanumeric_cnpj))
 
 Expected output:
+>>>True
 >>>True
 >>>True
 >>>True
@@ -98,13 +101,16 @@ cpf_number = '11144477735'
 masked_cpf_number = '111.444.777-35'
 cnpj_number = '11444777000161'
 masked_cnpj_number = '11.444.777/0001-61'
+alphanumeric_cnpj = '12ABC34501DE35'
 
 print(cpfcnpj.validate(cpf_number))
 print(cpfcnpj.validate(masked_cpf_number))
 print(cpfcnpj.validate(cnpj_number))
 print(cpfcnpj.validate(masked_cnpj_number))
+print(cpfcnpj.validate(alphanumeric_cnpj))
 
 Expected output:
+>>>True
 >>>True
 >>>True
 >>>True
@@ -145,6 +151,9 @@ Divirta-se!
 
 Changelog
 -----------
+1.9
+- Added official support for alphanumeric CNPJ (2026+)
+
 1.8
 - Dropped travis and python versions under 3.8
 
@@ -182,7 +191,10 @@ Changelog
 
 Log de mudanças
 -----------
-1,8
+1.9
+- Suporte oficial ao CNPJ alfanumérico (2026+)
+
+1.8
 - Travis fora e versões do Python abaixo de 3.8 não são mais suportadas
 
 1.7.2

--- a/pycpfcnpj/calculation.py
+++ b/pycpfcnpj/calculation.py
@@ -7,26 +7,51 @@ CNPJ_WEIGHTS = ((5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2),
 
 
 
+def convert_alphanumeric_to_numeric_values(alphanumeric_string):
+    """Converts alphanumeric characters to numeric values for CNPJ calculation.
+    
+    This function handles the new CNPJ format that includes letters and numbers.
+    Letters are converted to numbers using ASCII value minus 48.
+    is used to maintain compatibility with the existing weight system.
+    
+    :param alphanumeric_string: String containing numbers and letters
+    :type alphanumeric_string: string
+    :returns: list -- list of numeric values for calculation
+    """
+    result = []
+    for char in alphanumeric_string.upper():
+        if char.isdigit():
+            result.append(int(char))
+        elif char.isalpha():
+            result.append(ord(char.upper()) - 48)
+        else:
+            raise ValueError(f"Invalid character '{char}' in CNPJ")
+    return result
+
+
 def calculate_first_digit(number):
     """ This function calculates the first check digit of a
         cpf or cnpj.
 
-        :param number: cpf (length 9) or cnpf (length 12) 
-            string to check the first digit. Only numbers.
+        :param number: cpf (length 9) or cnpj (length 12) 
+            string to check the first digit. Can contain numbers and letters for new CNPJ format.
+            For new CNPJ format: 8 positions (root) + 4 positions (establishment order) = 12 alphanumeric positions
         :type number: string
         :returns: string -- the first digit
 
     """
-
-    sum = 0
-    if len(number) == 9:
+    # Convert alphanumeric to numeric values for calculation
+    numeric_values = convert_alphanumeric_to_numeric_values(number)
+    
+    total = 0
+    if len(numeric_values) == 9:
         weights = CPF_WEIGHTS[0]
     else:
         weights = CNPJ_WEIGHTS[0]
 
-    for i in range(len(number)):
-        sum = sum + int(number[i]) * weights[i]
-    rest_division = sum % DIVISOR
+    for i in range(len(numeric_values)):
+        total = total + numeric_values[i] * weights[i]
+    rest_division = total % DIVISOR
     if rest_division < 2:
         return '0'
     return str(11 - rest_division)
@@ -39,21 +64,23 @@ def calculate_second_digit(number):
         **This function must be called after the above.**
 
         :param number: cpf (length 10) or cnpj 
-            (length 13) number with the first digit. Only numbers.
+            (length 13) number with the first digit. Can contain numbers and letters for new CNPJ format.
+            For new CNPJ format: 12 alphanumeric positions + 1 first digit = 13 positions
         :type number: string
         :returns: string -- the second digit
 
     """
-
-    sum = 0
-    if len(number) == 10:
+    numeric_values = convert_alphanumeric_to_numeric_values(number)
+    
+    total = 0
+    if len(numeric_values) == 10:
         weights = CPF_WEIGHTS[1]
     else:
         weights = CNPJ_WEIGHTS[1]
 
-    for i in range(len(number)):
-        sum = sum + int(number[i]) * weights[i]
-    rest_division = sum % DIVISOR
+    for i in range(len(numeric_values)):
+        total = total + numeric_values[i] * weights[i]
+    rest_division = total % DIVISOR
     if rest_division < 2:
         return '0'
     return str(11 - rest_division)

--- a/pycpfcnpj/cnpj.py
+++ b/pycpfcnpj/cnpj.py
@@ -7,9 +7,10 @@ def validate(cnpj_number):
     """This function validates a CNPJ number.
 
     This function uses calculation package to calculate both digits
-    and then validates the number.
+    and then validates the number. Supports both old format (numbers only)
+    and new format (numbers and letters).
 
-    :param cnpj_number: a CNPJ number to be validated.  Only numbers.
+    :param cnpj_number: a CNPJ number to be validated. Can contain numbers and letters.
     :type cnpj_number: string
     :return: Bool -- True for a valid number, False otherwise.
 
@@ -18,6 +19,9 @@ def validate(cnpj_number):
     _cnpj = compat.clear_punctuation(cnpj_number)
 
     if len(_cnpj) != 14 or len(set(_cnpj)) == 1:
+        return False
+
+    if not _cnpj[-2:].isdigit():
         return False
 
     first_part = _cnpj[:12]

--- a/pycpfcnpj/compatible.py
+++ b/pycpfcnpj/compatible.py
@@ -1,7 +1,8 @@
 def check_special_characters(func):
     def wrapper(document):
-        not_digit = [i for i in clear_punctuation(document) if not i.isdigit()]
-        return False if not_digit else func(document)
+        cleared_doc = clear_punctuation(document)
+        invalid_chars = [i for i in cleared_doc if not (i.isdigit() or i.isalpha())]
+        return False if invalid_chars else func(document)
 
     return wrapper
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -9,6 +9,7 @@ class CalculationTests(unittest.TestCase):
     def setUp(self):
         self.first_part_cpf_number = '111444777'
         self.first_part_cnpj_number = '114447770001'
+        self.first_part_cnpj_alphanumeric = '12ABC34501DE'
 
     # TESTS FOR CPF DIGITS
     def test_cpf_calculate_first_digit_true(self):
@@ -64,3 +65,31 @@ class CalculationTests(unittest.TestCase):
         self.assertNotEqual(correct_second_digit,
                             calc.calculate_second_digit(updated_cnpj_number))
 
+    # TESTS FOR CNPJ ALPHANUMERIC DIGITS
+    def test_alphanumeric_cnpj_calculate_first_digit_true(self):
+        correct_first_digit = '3'
+        self.assertEqual(correct_first_digit,
+                         calc.calculate_first_digit(self.first_part_cnpj_alphanumeric))
+
+    def test_alphanumeric_cnpj_calculate_first_digit_false(self):
+        incorrect_first_digit = '5'
+        self.assertNotEqual(incorrect_first_digit,
+                            calc.calculate_first_digit(self.first_part_cnpj_alphanumeric))
+
+    def test_alphanumeric_cnpj_calculate_second_digit_true(self):
+        updated_cnpj = (
+            self.first_part_cnpj_alphanumeric +
+            calc.calculate_first_digit(self.first_part_cnpj_alphanumeric)
+        )
+        correct_second_digit = '5'
+        self.assertEqual(correct_second_digit,
+                         calc.calculate_second_digit(updated_cnpj))
+
+    def test_alphanumeric_cnpj_calculate_second_digit_false(self):
+        updated_cnpj = (
+            self.first_part_cnpj_alphanumeric +
+            calc.calculate_first_digit(self.first_part_cnpj_alphanumeric)
+        )
+        incorrect_second_digit = '7'
+        self.assertNotEqual(incorrect_second_digit,
+                            calc.calculate_second_digit(updated_cnpj))

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -15,8 +15,8 @@ class CNPJTests(unittest.TestCase):
         self.invalid_cnpj_with_alphabetic = "11444d777000161"
         self.invalid_cnpj_with_special_character = "+5575999769162"
 
-        self.valid_alphanumeric_cnpj = ["12ABC34501DE35",]
-        self.invalid_alphanumeric_dv = ["12ABC34501DE36",]
+        self.valid_alphanumeric_cnpj = "12ABC34501DE35"
+        self.invalid_alphanumeric_dv = "12ABC34501DE36"
         self.invalid_letters_in_verifier = ["12ABC34501DEA5", "12ABC34501DE3A",]
         self.invalid_alphanumeric_characters = ["12ABC34501DE@5", "12ABC34501DE 5",]
         self.invalid_alphanumeric_length = ["12ABC34501DE3", "12ABC34501DE350",]
@@ -47,26 +47,19 @@ class CNPJTests(unittest.TestCase):
         self.assertFalse(cnpj.validate(self.invalid_cnpj_with_special_character))
 
     def test_validate_alphanumeric_cnpj_true(self):
-        for cnpj_number in self.valid_alphanumeric_cnpj:
-            with self.subTest(cnpj=cnpj_number):
-                self.assertTrue(cnpj.validate(cnpj_number))
+        self.assertTrue(cnpj.validate(self.valid_alphanumeric_cnpj))
 
     def test_validate_alphanumeric_invalid_dv(self):
-        for cnpj_number in self.invalid_alphanumeric_dv:
-            with self.subTest(cnpj=cnpj_number):
-                self.assertFalse(cnpj.validate(cnpj_number))
+        self.assertFalse(cnpj.validate(self.invalid_alphanumeric_dv))
 
     def test_validate_alphanumeric_letters_in_verifier(self):
         for cnpj_number in self.invalid_letters_in_verifier:
-            with self.subTest(cnpj=cnpj_number):
-                self.assertFalse(cnpj.validate(cnpj_number))
+            self.assertFalse(cnpj.validate(cnpj_number))
 
     def test_validate_alphanumeric_invalid_characters(self):
         for cnpj_number in self.invalid_alphanumeric_characters:
-            with self.subTest(cnpj=cnpj_number):
-                self.assertFalse(cnpj.validate(cnpj_number))
+            self.assertFalse(cnpj.validate(cnpj_number))
 
     def test_validate_alphanumeric_invalid_length(self):
         for cnpj_number in self.invalid_alphanumeric_length:
-            with self.subTest(cnpj=cnpj_number):
-                self.assertFalse(cnpj.validate(cnpj_number))
+            self.assertFalse(cnpj.validate(cnpj_number))

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -15,6 +15,12 @@ class CNPJTests(unittest.TestCase):
         self.invalid_cnpj_with_alphabetic = "11444d777000161"
         self.invalid_cnpj_with_special_character = "+5575999769162"
 
+        self.valid_alphanumeric_cnpj = ["12ABC34501DE35",]
+        self.invalid_alphanumeric_dv = ["12ABC34501DE36",]
+        self.invalid_letters_in_verifier = ["12ABC34501DEA5", "12ABC34501DE3A",]
+        self.invalid_alphanumeric_characters = ["12ABC34501DE@5", "12ABC34501DE 5",]
+        self.invalid_alphanumeric_length = ["12ABC34501DE3", "12ABC34501DE350",]
+
     def test_validate_cnpj_true(self):
         self.assertTrue(cnpj.validate(self.valid_cnpj))
 
@@ -39,3 +45,28 @@ class CNPJTests(unittest.TestCase):
 
     def test_validate_cnpj_with_special_characters(self):
         self.assertFalse(cnpj.validate(self.invalid_cnpj_with_special_character))
+
+    def test_validate_alphanumeric_cnpj_true(self):
+        for cnpj_number in self.valid_alphanumeric_cnpj:
+            with self.subTest(cnpj=cnpj_number):
+                self.assertTrue(cnpj.validate(cnpj_number))
+
+    def test_validate_alphanumeric_invalid_dv(self):
+        for cnpj_number in self.invalid_alphanumeric_dv:
+            with self.subTest(cnpj=cnpj_number):
+                self.assertFalse(cnpj.validate(cnpj_number))
+
+    def test_validate_alphanumeric_letters_in_verifier(self):
+        for cnpj_number in self.invalid_letters_in_verifier:
+            with self.subTest(cnpj=cnpj_number):
+                self.assertFalse(cnpj.validate(cnpj_number))
+
+    def test_validate_alphanumeric_invalid_characters(self):
+        for cnpj_number in self.invalid_alphanumeric_characters:
+            with self.subTest(cnpj=cnpj_number):
+                self.assertFalse(cnpj.validate(cnpj_number))
+
+    def test_validate_alphanumeric_invalid_length(self):
+        for cnpj_number in self.invalid_alphanumeric_length:
+            with self.subTest(cnpj=cnpj_number):
+                self.assertFalse(cnpj.validate(cnpj_number))

--- a/tests/test_cpfcnpj.py
+++ b/tests/test_cpfcnpj.py
@@ -27,6 +27,13 @@ class CPFCNPJTests(unittest.TestCase):
         self.mascared_invalid_cnpj = "11.444.777/0001-62"
         self.mascared_invalid_cnpj_size = "114.447/7700-01"
 
+        self.valid_alphanumeric_cnpj = "12ABC34501DE35"
+        self.invalid_alphanumeric_cnpj_dv = "12ABC34501DE36"
+        self.invalid_alphanumeric_cnpj_size = "12ABC34501DE3"
+        self.invalid_alphanumeric_cnpj_whitespace = "12ABC 34501DE35"
+        self.invalid_alphanumeric_cnpj_with_special_char = "12ABC34501DE@5"
+        self.invalid_alphanumeric_cnpj_letters_in_verifier = "12ABC34501DEA5"
+
     def test_validate_cpf_true(self):
         self.assertTrue(cpfcnpj.validate(self.valid_cpf))
 
@@ -86,6 +93,24 @@ class CPFCNPJTests(unittest.TestCase):
 
     def test_validate_cpf_with_special_characters(self):
         self.assertFalse(cpfcnpj.validate(self.invalid_cpf_with_special_character))
+
+    def test_validate_alphanumeric_cnpj_true(self):
+        self.assertTrue(cpfcnpj.validate(self.valid_alphanumeric_cnpj))
+
+    def test_validate_alphanumeric_cnpj_invalid_dv(self):
+        self.assertFalse(cpfcnpj.validate(self.invalid_alphanumeric_cnpj_dv))
+
+    def test_validate_alphanumeric_cnpj_wrong_size(self):
+        self.assertFalse(cpfcnpj.validate(self.invalid_alphanumeric_cnpj_size))
+
+    def test_validate_alphanumeric_cnpj_with_whitespace(self):
+        self.assertFalse(cpfcnpj.validate(self.invalid_alphanumeric_cnpj_whitespace))
+
+    def test_validate_alphanumeric_cnpj_with_special_character(self):
+        self.assertFalse(cpfcnpj.validate(self.invalid_alphanumeric_cnpj_with_special_char))
+
+    def test_validate_alphanumeric_cnpj_letters_in_verifier(self):
+        self.assertFalse(cpfcnpj.validate(self.invalid_alphanumeric_cnpj_letters_in_verifier))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Support for alphanumeric CNPJ (2026+)

This PR adds official support for the new alphanumeric CNPJ format,
as defined by the Receita Federal / SERPRO specification (valid from 2026).

#### Changes
- Implements ASCII - 48 conversion for letters
- Enforces numeric-only check digits
- Adds unit tests for alphanumeric CNPJ validation and calculation
- Updates README and changelog

All existing tests remain unchanged and passing.